### PR TITLE
Start httpd as part of OTP startup

### DIFF
--- a/erl.config
+++ b/erl.config
@@ -1,5 +1,9 @@
 [
-    {cs_api, [
-        {port, 8000}
+    {inets, [
+        {services, [
+            {httpd, [
+                {proplist_file, "httpd.config"}
+            ]}
+        ]}
     ]}
 ].

--- a/httpd.config
+++ b/httpd.config
@@ -1,0 +1,7 @@
+[
+    {port, 8000},
+    {server_root,"/tmp"},
+    {document_root,"/tmp"},
+    {bind_address, {127, 0, 0, 1}},
+    {erl_script_alias, {"/cs", [cs_api_http]}}
+].

--- a/kill_inets.escript
+++ b/kill_inets.escript
@@ -1,0 +1,2 @@
+#!/usr/bin/env escript 
+main(_) -> application:stop(inets).

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
 {deps, []}.
 
 {shell, [
+    {script_file, "kill_inets.escript"},
     {config, "erl.config"},
     {apps, [cs_api]}
 ]}.

--- a/src/cs_api.app.src
+++ b/src/cs_api.app.src
@@ -5,9 +5,10 @@
     {mod, {cs_api_app, []}},
     {applications, [
         kernel,
-        stdlib
+        stdlib,
+        inets
     ]},
-    {env, [{port, 8000}]},
+    {env, []},
     {modules, []},
     {licenses, []},
     {links, []}

--- a/src/cs_api_app.erl
+++ b/src/cs_api_app.erl
@@ -9,24 +9,11 @@
 
 -export([start/2, start/0, stop/1]).
 
--define(DEF_PORT, 8000).
-
 start(_StartType, _StartArgs) ->
     start().
 
 start() ->
-    {ok, _Pid} = inets:start(httpd, [
-        {port, get_port()},
-        {server_root,"/tmp"},
-        {document_root,"/tmp"},
-        {bind_address, {127, 0, 0, 1}},
-        {erl_script_alias, {"/cs", [cs_api_http]}}
-    ]),
     cs_api_sup:start_link().
 
 stop(_State) ->
-    ok = inets:stop(httpd, {{127, 0, 0, 1}, get_port()}),
     ok.
-
-get_port() ->
-    application:get_env(cs_api, port, ?DEF_PORT).


### PR DESCRIPTION
Refactored to start the HTTP service automatically during the OTP startup process.
That required a bit of investigation, as it turned out that `rebar3` starts `inets` application for its own purposes before starting the user application supposed to run in the shell. Due to this, `inets` doesn't read custom configuration, and effectively doesn't start `httpd` service. Fortunately, there's a workaround from `rebar3` developer: a hook script that runs before booting the user application and stops `inets`.